### PR TITLE
version bump (chirpy): 6.4.1

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   release:
   push:
+    branches:
+      - main
+      - 'releases/**'
 
 jobs:
   build:

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "jekyll-theme-chirpy", "~> 6.3.1"
+gem "jekyll-theme-chirpy", "~> 6.4.1"
 
 group :test do
   gem "html-proofer", "~> 4.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-theme-chirpy (6.3.1)
+    jekyll-theme-chirpy (6.4.1)
       jekyll (~> 4.3)
       jekyll-archives (~> 2.2)
       jekyll-include-cache (~> 0.2)
@@ -119,7 +119,7 @@ DEPENDENCIES
   html-proofer (~> 4.4)
   http_parser.rb (~> 0.6.0)
   jekyll-compose
-  jekyll-theme-chirpy (~> 6.3.1)
+  jekyll-theme-chirpy (~> 6.4.1)
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1.1)


### PR DESCRIPTION
- chirpy `6.3.1` to `6.4.1`

> Autogenerated with [belltower](https://github.com/kdpuvvadi/belltower)
